### PR TITLE
Providing an example config file for users

### DIFF
--- a/src/main/resources/example.properties
+++ b/src/main/resources/example.properties
@@ -1,0 +1,34 @@
+# --------------------------------------------------------------------------------
+# --------------------------- LLM API Credentials --------------------------------
+# --------------------------------------------------------------------------------
+llm.api.key=REPLACE_WITH_YOUR_OPENAI_API_KEY
+llm.api.uri=https://api.openai.com/v1/chat/completions
+
+
+# --------------------------------------------------------------------------------
+# ------------------------------ GPT API Credentials -----------------------------
+# --------------------------------------------------------------------------------
+gpt.message.system=system
+gpt.message.system.content=You are a helpful Java developer. Provide Java code and comments only, starting with a set of triple backticks.
+gpt.message.user=user
+
+
+# --------------------------------------------------------------------------------
+# ---------------------------- Essential GPT Prompts -----------------------------
+# --------------------------------------------------------------------------------
+gpt.prompt.start=My compiler is running with the Checker Framework, and it issues an error about the program above. Here's the error:
+gpt.prompt.end=Can you rewrite the program to avoid this error from the compiler? Ensure to include the entire method in your response and also add comments for each line you modify.
+
+
+# --------------------------------------------------------------------------------
+# --------------------------- Checker Framework Misc -----------------------------
+# --------------------------------------------------------------------------------
+checker.commands=org.checkerframework.checker.resourceleak.ResourceLeakChecker,org.checkerframework.checker.nullness.NullnessChecker
+checker.classpath=libs/checker.jar:libs/checker.jar:libs/checker-qual.jar:libs/checker-util.jar
+checker.jar.file=libs/checker.jar
+
+
+# --------------------------------------------------------------------------------
+# --------------------------- Specimin Framework Misc ----------------------------
+# --------------------------------------------------------------------------------
+specimin.tool.path=REPLACE_WITH_YOUR_SPECIMIN_PATH


### PR DESCRIPTION
The users will convert this example.properties file into a config.properties.

They will replace the following placeholders:
- llm.api.key with their own OpenAI key.
- specimin.tool.path with their path to Specimin

The instructions to do so are in the Usage section of the README.MD, which is currently under review.