### PR TITLE
allow ASHE to run without large language models, skipping the error c…

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -119,8 +119,9 @@ In our prototype, those three tools are:
     - Example: `--targetMethod com.example.Example#foo()`
 
 **Optional Argument:**
-- **--model:** large language model to use. Currently, only GPT-4 and mock responses are supported.
-    - Example: `gpt-4` or `mock`
+- **--model:** large language model to use. Currently, only GPT-4, mock, and dryrun are supported, where mock is a
+  test mode that responds with a mock patch and dryrun is a test mode that skips the error correction process.
+    - Example: `gpt-4`, `mock`, or `dryrun`
     - Note: if no LLM is specified, the default is `gpt-4`
 
 ### Logging
@@ -187,8 +188,9 @@ cloning and Java file processing.
     - Example: `/absolute/path/to/project`
 
 **Optional Argument:**
-- **--model:** large language model to use. Currently, only GPT-4 and mock responses are supported.
-    - Example: `gpt-4` or `mock`
+- **--model:** large language model to use. Currently, only GPT-4, mock, and dryrun are supported, where mock is a
+  test mode that responds with a mock patch and dryrun is a test mode that skips the error correction process.
+    - Example: `gpt-4`, `mock`, or `dryrun`
     - Note: if no LLM is specified, the default is `gpt-4`
 
 ### Running RepositoryAutomationEngine
@@ -241,8 +243,9 @@ file containing the details of each repository. Follow these steps to create and
     - Example: `/path/to/clone/directory`
 
 **Optional Argument:**
-- **--model:** large language model to use. Currently, only GPT-4 and mock responses are supported.
-    - Example: `gpt-4` or `mock`
+- **--model:** large language model to use. Currently, only GPT-4, mock, and dryrun are supported, where mock is a
+test mode that responds with a mock patch and dryrun is a test mode that skips the error correction process.
+    - Example: `gpt-4`, `mock`, or `dryrun`
     - Note: if no LLM is specified, the default is `gpt-4`
 
 <br/>

--- a/src/main/java/edu/njit/jerse/ashe/Ashe.java
+++ b/src/main/java/edu/njit/jerse/ashe/Ashe.java
@@ -94,6 +94,14 @@ public class Ashe {
         String speciminTempDir = corrector.minimizeTargetFile(root, targetFile, targetMethod);
         final String sourceFilePath = String.valueOf(Paths.get(speciminTempDir, targetFile));
 
+        // The purpose of the dryrun mode is to test the Specimin minimization functionality.
+        // Therefore, skipping the error correction process is acceptable.
+        if (model.equals("dryrun")) {
+            LOGGER.info("Dryrun mode enabled. Skipping error correction.");
+            LOGGER.info("Exiting...");
+            return;
+        }
+
         boolean errorsReplacedInTargetFile = corrector.fixTargetFileErrorsWithModel(sourceFilePath, targetMethod, model);
 
         if (!errorsReplacedInTargetFile) {
@@ -136,6 +144,7 @@ public class Ashe {
      *                     <ul>
      *                         <li>"gpt-4" to run the {@link GptModel#GPT_4} model</li>
      *                         <li>"mock" to run the mock response defined in predefined_responses.txt</li>
+     *                         <li>"dryrun" to run {@code Ashe#run} without a model, skipping the error correction process</li>
      *                         <li>if this argument is omitted, a default model will be used ({@link GptModel#GPT_4})</li>
      *                     </ul>
      *                 </li>

--- a/src/main/java/edu/njit/jerse/ashe/utils/ModelValidator.java
+++ b/src/main/java/edu/njit/jerse/ashe/utils/ModelValidator.java
@@ -1,5 +1,6 @@
 package edu.njit.jerse.ashe.utils;
 
+import edu.njit.jerse.ashe.Ashe;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -26,11 +27,11 @@ public class ModelValidator {
      * <ul>
      *     <li>"gpt-4" - represents the GPT-4 model</li>
      *     <li>"mock" - represents a mock model for testing or development purposes</li>
+     *     <li>"dryrun" - dryrun allows {@link Ashe#run} to run without a model, skipping the error correction process</li>
      * </ul>
-     *
      * TODO: Add more models to this list once they are handled by the application.
      */
-    private static final List<String> VALID_MODELS = List.of("gpt-4", "mock");
+    private static final List<String> VALID_MODELS = List.of("gpt-4", "mock", "dryrun");
 
     /**
      * Gets the default model name. This method returns the first model in the list of valid models.

--- a/src/main/java/edu/njit/jerse/automation/AsheAutomation.java
+++ b/src/main/java/edu/njit/jerse/automation/AsheAutomation.java
@@ -69,6 +69,7 @@ public class AsheAutomation {
      *
      * @param javaFilePath    the path to the Java file to be processed
      * @param projectRootPath the root path of the project, must be a prefix of the javaFile's absolute path
+     * @param model           the model to use for error correction
      * @throws IOException          if an I/O error occurs when opening or parsing the file
      * @throws ExecutionException   if {@link Ashe} encounters an error during execution
      * @throws InterruptedException if {@link Ashe}'s execution is interrupted
@@ -195,6 +196,7 @@ public class AsheAutomation {
      *                     <ul>
      *                         <li>"gpt-4" to run the {@link GptModel#GPT_4} model</li>
      *                         <li>"mock" to run the mock response defined in predefined_responses.txt</li>
+     *                         <li>"dryrun" to run {@link Ashe#run} without a model, skipping the error correction process</li>
      *                         <li>if this argument is omitted, a default model will be used ({@link GptModel#GPT_4})</li>
      *                     </ul>
      *                 </li>

--- a/src/main/java/edu/njit/jerse/automation/RepositoryAutomationEngine.java
+++ b/src/main/java/edu/njit/jerse/automation/RepositoryAutomationEngine.java
@@ -1,5 +1,6 @@
 package edu.njit.jerse.automation;
 
+import edu.njit.jerse.ashe.Ashe;
 import edu.njit.jerse.ashe.llm.openai.models.GptModel;
 import edu.njit.jerse.ashe.utils.ModelValidator;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -226,6 +227,7 @@ public class RepositoryAutomationEngine {
      *                     <ul>
      *                         <li>"gpt-4" to run the {@link GptModel#GPT_4} model</li>
      *                         <li>"mock" to run the mock response defined in predefined_responses.txt</li>
+     *                         <li>"dryrun" to run {@link Ashe#run} without a model, skipping the error correction process</li>
      *                         <li>if this argument is omitted, a default model will be used ({@link GptModel#GPT_4})</li>
      *                     </ul>
      *                 </li>


### PR DESCRIPTION
…orrection

The purpose of this PR is to allow users to enter a dryrun mode, where they do not need to provide a correction for any errors. We want to test functionality of Specimin.

Note: #31 should be merged before this is complete. There will be merge conflicts if we do not resolve that beforehand.